### PR TITLE
Change size of picture to remove bottom scrolling

### DIFF
--- a/src/components/shared/LandingStock.jsx
+++ b/src/components/shared/LandingStock.jsx
@@ -9,7 +9,7 @@ export default function LandingStock() {
           alt="local market"
           style={{
             height: "35vh",
-            width: "120%",
+            width: "100vw",
             objectFit: "cover"
           }}
         />


### PR DESCRIPTION
Noticed the landing page could scroll to the right for white space due to size of image.